### PR TITLE
Bugfix/item icon rendering

### DIFF
--- a/Content/_MAIN/Characters/Player/BP_MainPlayerCharacter.uasset
+++ b/Content/_MAIN/Characters/Player/BP_MainPlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:154a648aa9f93f5ca43b1a8e62fbbfa3000940dc79baec590ae01018a1c3db20
-size 156688
+oid sha256:ce0723035f87cf0382f8e1171fae5907bbd5c2c994f6a600c4775fe5af67b46e
+size 149473

--- a/Content/_MAIN/Data/Item/DataAssets/Resources/DA_PDA_WoodenLog.uasset
+++ b/Content/_MAIN/Data/Item/DataAssets/Resources/DA_PDA_WoodenLog.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9cc2daf0b476e7e574501a97b9ee22bf5a56616aa706ddce59f948c5dc76798
-size 2994

--- a/Content/_MAIN/Data/Item/DataAssets/Resources/DA_Rw_Res_Apple.uasset
+++ b/Content/_MAIN/Data/Item/DataAssets/Resources/DA_Rw_Res_Apple.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c352b20bd616e31c4ce4a165dc61dc5df4f01f7f07d0a0f4467d057e72e1c795
+size 2512

--- a/Content/_MAIN/Data/Item/DataAssets/Resources/DA_Rw_Res_Stone.uasset
+++ b/Content/_MAIN/Data/Item/DataAssets/Resources/DA_Rw_Res_Stone.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3764c2c96daa495722c12e8e8a6e1a0b687b47fa2d3a6dfa9088371b2db22076
+size 2510

--- a/Content/_MAIN/Data/Item/DataAssets/Resources/DA_WoodenLog.uasset
+++ b/Content/_MAIN/Data/Item/DataAssets/Resources/DA_WoodenLog.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:90a74d2de4ed6f33f028778a533f8fa8642932de646ef7ae91c7eef9ed3cc3cb
-size 2880
+oid sha256:e14535d14fc8071e453b037627caeb0f955b137329361f536f14e41be38e5bcb
+size 2963

--- a/Content/_MAIN/Data/Item/DataTables/DT_Items.uasset
+++ b/Content/_MAIN/Data/Item/DataTables/DT_Items.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e67ae7f0157edabbb4e904d5c874e3d67ece078d90ae0ea64ba4a0d0b0edec71
+size 5089

--- a/Content/_MAIN/Editor/Tools/WBP_ComboEntry.uasset
+++ b/Content/_MAIN/Editor/Tools/WBP_ComboEntry.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:357c2d1ac3a8bd24581cce1b80a0d64922cec475799aa29483e8bd24c68a8f1c
+size 35187

--- a/Content/_MAIN/Editor/Tools/WBP_ItemFactoryTool.uasset
+++ b/Content/_MAIN/Editor/Tools/WBP_ItemFactoryTool.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:130aa5fe22f42a6cf2e4c1965e492936998d394dfd79c09c569b54d2801e61e6
+size 422508

--- a/Content/_MAIN/Game/BP_MedievalGameMode.uasset
+++ b/Content/_MAIN/Game/BP_MedievalGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c17565f8eb280db58aeed37e2664d7616859c71e301599b5a3b744ff44c5e90
+oid sha256:4dc8d96d4380c2f01d169dd2870e8811dedd5a8cc90a3a4b694c1e01a23945ef
 size 14770

--- a/Content/_MAIN/Game/Components/BPC_PlayerInventoryComponent.uasset
+++ b/Content/_MAIN/Game/Components/BPC_PlayerInventoryComponent.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3f04d04e6e0a499f318a3d8bf68876c7191392d1ae8a287f3a5d37c47ea037a
-size 15161
+oid sha256:1fbf12ab816372c75fb396f1ae25aec1d2d82105dd3a8d3f11c4acc6b54a564b
+size 15198

--- a/Content/_MAIN/Input/Actions/IA_ToggleInventory.uasset
+++ b/Content/_MAIN/Input/Actions/IA_ToggleInventory.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbe82d47d9e197ebd9b17f7c9ede58afaf62984f7aacaed230e6d7237251d759
+oid sha256:0581aa5a6d4bb8840622601ddf823755716b168ea8be9d64941e3cd9af04ccdf
 size 1435

--- a/Content/_MAIN/Input/IMC_Default.uasset
+++ b/Content/_MAIN/Input/IMC_Default.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f1afc34e385bd1c743de22a2995a633517c062ccb927e71b3208f32121b0fe4
-size 15850
+oid sha256:6bf4d5a30842bfe281a5e3d71c26e736ae5657083beac4d7a3ed07dc47d2bd81
+size 15509

--- a/Content/_MAIN/Input/IMC_Default.uasset
+++ b/Content/_MAIN/Input/IMC_Default.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6bf4d5a30842bfe281a5e3d71c26e736ae5657083beac4d7a3ed07dc47d2bd81
+oid sha256:de32d229782f408149d7640c9af767071542e35994fa5d3f076a74acfb979595
 size 15509

--- a/Content/_MAIN/Maps/Map_TEST.umap
+++ b/Content/_MAIN/Maps/Map_TEST.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e020343b1ef3d4e661c885850328cee1fc948b813f1573e36dd5b3f160d310b
+oid sha256:60031b67b567657c4fc3d2c01bd633ef107ce16556ba9dbfd5d8d38fb0637d7c
 size 45978

--- a/Content/_MAIN/Maps/Map_TEST.umap
+++ b/Content/_MAIN/Maps/Map_TEST.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:60031b67b567657c4fc3d2c01bd633ef107ce16556ba9dbfd5d8d38fb0637d7c
-size 45978
+oid sha256:04eb27c0f9386c17f15d6e7ec3ebdf9bcfd4af6c5043b6370d44dfeb770754bd
+size 46039

--- a/Content/_MAIN/UI/W_MainUILayout.uasset
+++ b/Content/_MAIN/UI/W_MainUILayout.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b72ef2d33fe5aff9694d05b052a23dd7c3138a36e7cdf9bcf1cc20cc37a8560
-size 22582
+oid sha256:f714bf4d6e48db11c66f00c8db7100254803ab45c6ba2e7897b065871e094ee7
+size 22886

--- a/Content/_MAIN/UI/Widgets/Inventory/W_GameInventoryLayout.uasset
+++ b/Content/_MAIN/UI/Widgets/Inventory/W_GameInventoryLayout.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f1daa8d15552ddbfabb02d596440c9c49aca0bcbca3804045ffbfc7721d427c
-size 39714
+oid sha256:6737245fc7d62bf322d62ca5959d4487da7e0aa96abefbef3603113a9f9880bf
+size 39867

--- a/Source/SurvivalGame.Target.cs
+++ b/Source/SurvivalGame.Target.cs
@@ -11,5 +11,11 @@ public class SurvivalGameTarget : TargetRules
 		DefaultBuildSettings = BuildSettingsVersion.V5;
 
 		ExtraModuleNames.AddRange( new string[] { "SurvivalGame" } );
+		RegisterModulesCreatedByRider();
+	}
+
+	private void RegisterModulesCreatedByRider()
+	{
+		ExtraModuleNames.AddRange(new string[] { "SurvivalGameEditor" });
 	}
 }

--- a/Source/SurvivalGame/Private/Data/Library/ItemDataAccessLibrary.cpp
+++ b/Source/SurvivalGame/Private/Data/Library/ItemDataAccessLibrary.cpp
@@ -1,0 +1,264 @@
+#include "Data/Library/ItemDataAccessLibrary.h"
+#include "Engine/AssetManager.h"
+#include "Engine/StreamableManager.h"
+
+UTexture2D* UItemDataAccessLibrary::GetItemIcon(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return nullptr;
+    }
+    
+    static const FString ContextString(TEXT("GetItemIcon"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData || RowData->ItemIcon.IsNull())
+    {
+        return nullptr;
+    }
+    
+    return RowData->ItemIcon.LoadSynchronous();
+}
+
+void UItemDataAccessLibrary::GetItemIconAsync(UObject* WorldContextObject, const UDataTable* DataTable, FName RowName, UTexture2D*& OutTexture, FLatentActionInfo LatentInfo)
+{
+    OutTexture = nullptr;
+    
+    if (!WorldContextObject || !DataTable || RowName.IsNone())
+    {
+        return;
+    }
+    
+    static const FString ContextString(TEXT("GetItemIconAsync"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData || RowData->ItemIcon.IsNull())
+    {
+        return;
+    }
+    
+    // Create a weak reference to track if the world context object is destroyed
+    TWeakObjectPtr<UObject> WeakWorldContextObject(WorldContextObject);
+    
+    // Start async load
+    FStreamableManager& StreamableManager = UAssetManager::GetStreamableManager();
+    StreamableManager.RequestAsyncLoad(
+        RowData->ItemIcon.ToSoftObjectPath(),
+        FStreamableDelegate::CreateLambda([WeakWorldContextObject, &OutTexture, RowData, LatentInfo]() {
+            // Check if the context is still valid
+            if (WeakWorldContextObject.IsValid())
+            {
+                OutTexture = RowData->ItemIcon.Get();
+                
+                // Complete the latent action
+                if (UWorld* World = GEngine->GetWorldFromContextObject(WeakWorldContextObject.Get(), EGetWorldErrorMode::LogAndReturnNull))
+                {
+                    FLatentActionManager& LatentActionManager = World->GetLatentActionManager();
+                    // This is the line that needs to be fixed - RemoveActionsForObject only takes one parameter
+                    LatentActionManager.RemoveActionsForObject(WeakWorldContextObject.Get());
+                }
+            }
+        })
+    );
+}
+
+FText UItemDataAccessLibrary::GetItemName(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return FText::GetEmpty();
+    }
+    
+    static const FString ContextString(TEXT("GetItemName"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return FText::GetEmpty();
+    }
+    
+    return RowData->ItemName;
+}
+
+FText UItemDataAccessLibrary::GetItemDescription(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return FText::GetEmpty();
+    }
+    
+    static const FString ContextString(TEXT("GetItemDescription"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return FText::GetEmpty();
+    }
+    
+    return RowData->ItemDescription;
+}
+
+E_ItemCategory UItemDataAccessLibrary::GetItemCategory(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return E_ItemCategory::None;
+    }
+    
+    static const FString ContextString(TEXT("GetItemCategory"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return E_ItemCategory::None;
+    }
+    
+    return RowData->ItemCategory;
+}
+
+E_ItemType UItemDataAccessLibrary::GetItemType(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return E_ItemType::None;
+    }
+    
+    static const FString ContextString(TEXT("GetItemType"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return E_ItemType::None;
+    }
+    
+    return RowData->ItemType;
+}
+
+bool UItemDataAccessLibrary::GetItemRowData(const UDataTable* DataTable, FName RowName, FItemDataTableRow& OutRowData)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return false;
+    }
+    
+    static const FString ContextString(TEXT("GetItemRowData"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return false;
+    }
+    
+    OutRowData = *RowData;
+    return true;
+}
+
+bool UItemDataAccessLibrary::IsItemStackable(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return false;
+    }
+    
+    static const FString ContextString(TEXT("IsItemStackable"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return false;
+    }
+    
+    return RowData->bStackable;
+}
+
+bool UItemDataAccessLibrary::IsItemConsumable(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return false;
+    }
+    
+    static const FString ContextString(TEXT("IsItemConsumable"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return false;
+    }
+    
+    return (RowData->ItemCategory == E_ItemCategory::Consumable) || 
+           (RowData->ItemType == E_ItemType::Food) || 
+           (RowData->ItemType == E_ItemType::Potion);
+}
+
+bool UItemDataAccessLibrary::IsItemWeapon(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return false;
+    }
+    
+    static const FString ContextString(TEXT("IsItemWeapon"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return false;
+    }
+    
+    return RowData->ItemCategory == E_ItemCategory::Equipment;
+}
+
+bool UItemDataAccessLibrary::IsItemResource(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return false;
+    }
+    
+    static const FString ContextString(TEXT("IsItemResource"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return false;
+    }
+    
+    return RowData->ItemCategory == E_ItemCategory::Resource;
+}
+
+int32 UItemDataAccessLibrary::GetItemMaxStackSize(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return 1;
+    }
+    
+    static const FString ContextString(TEXT("GetItemMaxStackSize"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return 1;
+    }
+    
+    return RowData->bStackable ? RowData->StackSize : 1;
+}
+
+float UItemDataAccessLibrary::GetItemWeight(const UDataTable* DataTable, FName RowName)
+{
+    if (!DataTable || RowName.IsNone())
+    {
+        return 0.0f;
+    }
+    
+    static const FString ContextString(TEXT("GetItemWeight"));
+    FItemDataTableRow* RowData = DataTable->FindRow<FItemDataTableRow>(RowName, ContextString);
+    
+    if (!RowData)
+    {
+        return 0.0f;
+    }
+    
+    return RowData->ItemWeight;
+}

--- a/Source/SurvivalGame/Private/Data/PrimaryData/ItemInfo.cpp
+++ b/Source/SurvivalGame/Private/Data/PrimaryData/ItemInfo.cpp
@@ -1,4 +1,6 @@
 #include "Data/PrimaryData/ItemInfo.h"
+
+#include "DataTables/ItemDataTableRow.h"
 #include "Engine/Texture2D.h"
 
 UItemInfo::UItemInfo()
@@ -106,6 +108,36 @@ int32 UItemInfo::GetMaxHP() const
             return ItemBaseHP;
     }
 }
+
+bool UItemInfo::LoadFromDataTable(const UDataTable* DataTable)
+{
+    if (!DataTable || DataTableRowName.IsNone())
+    {
+        return false;
+    }
+
+    FItemDataTableRow* Row = DataTable->FindRow<FItemDataTableRow>(DataTableRowName, TEXT(""));
+    if (!Row)
+    {
+        return false;
+    }
+
+    // Copy data from table row to this asset
+    RegistryKey = Row->RegistryKey;
+    ItemCategory = Row->ItemCategory;
+    ItemType = Row->ItemType;
+    ItemName = Row->ItemName;
+    ItemDescription = Row->ItemDescription;
+    ItemWeight = Row->ItemWeight;
+    ItemBaseHP = Row->ItemBaseHP;
+    ItemDamage = Row->ItemDamage;
+    bStackable = Row->bStackable;
+    StackSize = Row->StackSize;
+    ItemIcon = Row->ItemIcon;
+
+    return true;
+}
+
 
 FItemStructure UItemInfo::CreateItemInstance(int32 Quantity) const
 {

--- a/Source/SurvivalGame/Public/Data/DataTables/ItemDataTableRow.h
+++ b/Source/SurvivalGame/Public/Data/DataTables/ItemDataTableRow.h
@@ -1,0 +1,110 @@
+// ItemDataTableRow.h
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+#include "ItemEnums.h"
+#include "ItemDataTableRow.generated.h"
+
+USTRUCT(BlueprintType)
+struct FItemDataTableRow : public FTableRowBase
+{
+    GENERATED_BODY()
+
+    // References
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Core")
+    TSoftObjectPtr<UTexture2D> ItemIcon;
+    
+    // Core Properties
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Core")
+    FName RegistryKey;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Core")
+    E_ItemCategory ItemCategory;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Core")
+    E_ItemType ItemType;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Core")
+    FText ItemName;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Core")
+    FText ItemDescription;
+
+    // Stats
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Stats")
+    float ItemWeight;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Stats")
+    int32 ItemBaseHP;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Stats")
+    int32 ItemDamage;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Stats")
+    bool bStackable;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Stats")
+    int32 StackSize;
+
+    FItemDataTableRow()
+       : RegistryKey(NAME_None)
+       , ItemCategory(E_ItemCategory::None)
+       , ItemType(E_ItemType::None)
+       , ItemWeight(0.0f)
+       , ItemBaseHP(100)
+       , ItemDamage(0)
+       , bStackable(false)
+       , StackSize(1)
+    {}
+
+    // Getter functions
+    FORCEINLINE UTexture2D* GetItemIcon() const { return ItemIcon.LoadSynchronous(); }
+    FORCEINLINE FName GetRegistryKey() const { return RegistryKey; }
+    FORCEINLINE E_ItemCategory GetItemCategory() const { return ItemCategory; }
+    FORCEINLINE E_ItemType GetItemType() const { return ItemType; }
+    FORCEINLINE FText GetItemName() const { return ItemName; }
+    FORCEINLINE FText GetItemDescription() const { return ItemDescription; }
+    FORCEINLINE float GetItemWeight() const { return ItemWeight; }
+    FORCEINLINE int32 GetItemBaseHP() const { return ItemBaseHP; }
+    FORCEINLINE int32 GetItemDamage() const { return ItemDamage; }
+    FORCEINLINE bool IsStackable() const { return bStackable; }
+    FORCEINLINE int32 GetStackSize() const { return StackSize; }
+    
+    // Utility functions
+    FORCEINLINE bool IsValid() const { return !RegistryKey.IsNone(); }
+    FORCEINLINE bool CanStack(const FItemDataTableRow& OtherItem) const
+    {
+        return bStackable && OtherItem.bStackable && RegistryKey == OtherItem.RegistryKey;
+    }
+    
+    // Get the stack limit for this item
+    FORCEINLINE int32 GetMaxStackSize() const { return bStackable ? StackSize : 1; }
+    
+    // Check if item is a specific category
+    FORCEINLINE bool IsWeapon() const { return ItemCategory == E_ItemCategory::Equipment; }
+    FORCEINLINE bool IsArmor() const { return ItemCategory == E_ItemCategory::Wearable; }
+    FORCEINLINE bool IsConsumable() const { return ItemCategory == E_ItemCategory::Consumable || ItemType == E_ItemType::Food || ItemType == E_ItemType::Potion; }
+    FORCEINLINE bool IsResource() const { return ItemCategory == E_ItemCategory::Resource; }
+    
+    // Get formatted information string
+    FString GetItemInfoString() const
+    {
+        FString Result = FString::Printf(TEXT("%s\n"), *ItemName.ToString());
+        Result += FString::Printf(TEXT("Type: %s\n"), *UEnum::GetDisplayValueAsText(ItemCategory).ToString());
+        Result += FString::Printf(TEXT("Weight: %.1f\n"), ItemWeight);
+        
+        if (ItemDamage > 0)
+        {
+            Result += FString::Printf(TEXT("Damage: %d\n"), ItemDamage);
+        }
+        
+        if (bStackable)
+        {
+            Result += FString::Printf(TEXT("Stack Size: %d\n"), StackSize);
+        }
+        
+        Result += FString::Printf(TEXT("\n%s"), *ItemDescription.ToString());
+        return Result;
+    }
+};

--- a/Source/SurvivalGame/Public/Data/Library/ItemDataAccessLibrary.h
+++ b/Source/SurvivalGame/Public/Data/Library/ItemDataAccessLibrary.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "Data/DataTables/ItemDataTableRow.h" 
+#include "ItemDataAccessLibrary.generated.h"
+
+/**
+ * Utility library for accessing and manipulating item data from data tables
+ */
+UCLASS(Blueprintable, BlueprintType, meta = (DisplayName = "Item Data Access Library"))
+class SURVIVALGAME_API UItemDataAccessLibrary : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+    
+public:
+    /**
+     * Retrieves an item's icon texture from a data table
+     * @param DataTable The data table containing the item data
+     * @param RowName The row name to look up
+     * @return The item's icon texture or nullptr if not found
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Properties")
+    static UTexture2D* GetItemIcon(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Asynchronously loads an item's icon texture from a data table
+     * @param WorldContextObject World context
+     * @param DataTable The data table containing the item data
+     * @param RowName The row name to look up
+     * @param OutTexture The loaded texture (output parameter)
+     * @param LatentInfo Latent action information
+     */
+    UFUNCTION(BlueprintCallable, Category = "Item Data|Properties", meta = (Latent, LatentInfo = "LatentInfo", WorldContext = "WorldContextObject"))
+    static void GetItemIconAsync(UObject* WorldContextObject, const UDataTable* DataTable, FName RowName, UTexture2D*& OutTexture, FLatentActionInfo LatentInfo);
+    
+    /**
+     * Gets an item's display name
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Properties")
+    static FText GetItemName(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Gets an item's description text
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Properties")
+    static FText GetItemDescription(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Gets an item's category
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Properties")
+    static E_ItemCategory GetItemCategory(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Gets an item's type
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Properties")
+    static E_ItemType GetItemType(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Gets complete row data for an item
+     */
+    UFUNCTION(BlueprintCallable, Category = "Item Data|Row Access")
+    static bool GetItemRowData(const UDataTable* DataTable, FName RowName, FItemDataTableRow& OutRowData);
+    
+    /**
+     * Checks if an item is stackable
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Attributes")
+    static bool IsItemStackable(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Checks if an item is consumable
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Attributes")
+    static bool IsItemConsumable(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Checks if an item is a weapon
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Attributes")
+    static bool IsItemWeapon(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Checks if an item is a resource
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Attributes")
+    static bool IsItemResource(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Gets an item's maximum stack size
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Properties")
+    static int32 GetItemMaxStackSize(const UDataTable* DataTable, FName RowName);
+    
+    /**
+     * Gets an item's weight
+     */
+    UFUNCTION(BlueprintPure, Category = "Item Data|Properties")
+    static float GetItemWeight(const UDataTable* DataTable, FName RowName);
+};

--- a/Source/SurvivalGame/Public/Data/PrimaryData/ItemInfo.h
+++ b/Source/SurvivalGame/Public/Data/PrimaryData/ItemInfo.h
@@ -31,6 +31,14 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Item")
     FItemStructure CreateItemInstance(int32 Quantity = 1) const;
 
+	// Link to Data Table row
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category = "Data Table")
+	FName DataTableRowName;
+
+	// Function to load data from table
+	UFUNCTION(BlueprintCallable, Category = "Initialization")
+	bool LoadFromDataTable(const UDataTable* DataTable);
+
     /** Core Properties */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Item|Core")
     FName RegistryKey;

--- a/Source/SurvivalGame/Public/Enums/ItemEnums.h
+++ b/Source/SurvivalGame/Public/Enums/ItemEnums.h
@@ -33,6 +33,7 @@ enum class E_ItemCategory : uint8
     None        UMETA(DisplayName = "None"),
     Resource    UMETA(DisplayName = "Resource"),
     Equipment   UMETA(DisplayName = "Equipable"),
+    Wearable    UMETA(DisplayName = "Wearable"),
     Consumable  UMETA(DisplayName = "Consumable"),
     Buildable   UMETA(DisplayName = "Buildable"),
     Quest       UMETA(DisplayName = "Quest"),

--- a/Source/SurvivalGame/SurvivalGame.Build.cs
+++ b/Source/SurvivalGame/SurvivalGame.Build.cs
@@ -80,7 +80,12 @@ public class SurvivalGame : ModuleRules
                 "UnrealEd",
                 "EditorFramework",
                 "EditorStyle",
-                "EditorSubsystem"
+                "EditorSubsystem",
+                "Blutility",           
+                "UMGEditor",           
+                "AssetTools",          
+                "ContentBrowser",      
+                "EditorScriptingUtilities"
             });
         }
 

--- a/Source/SurvivalGameEditor.Target.cs
+++ b/Source/SurvivalGameEditor.Target.cs
@@ -11,5 +11,11 @@ public class SurvivalGameEditorTarget : TargetRules
 		DefaultBuildSettings = BuildSettingsVersion.V5;
 
 		ExtraModuleNames.AddRange( new string[] { "SurvivalGame" } );
+		RegisterModulesCreatedByRider();
+	}
+
+	private void RegisterModulesCreatedByRider()
+	{
+		ExtraModuleNames.AddRange(new string[] { "SurvivalGameEditor" });
 	}
 }

--- a/Source/SurvivalGameEditor/Private/SurvivalGameEditor.cpp
+++ b/Source/SurvivalGameEditor/Private/SurvivalGameEditor.cpp
@@ -1,0 +1,24 @@
+﻿#include "SurvivalGameEditor.h"
+#include "Tools/ItemFactory.h"
+#include "UObject/StrongObjectPtr.h"
+
+#define LOCTEXT_NAMESPACE "FSurvivalGameEditorModule"
+
+void FSurvivalGameEditorModule::StartupModule()
+{
+	// Create the ItemFactory object in the transient package
+	UItemFactory* FactoryObject = NewObject<UItemFactory>(GetTransientPackage(), UItemFactory::StaticClass());
+
+	// Assign to TStrongObjectPtr, which keeps a valid reference to the object
+	ItemFactory = TStrongObjectPtr<UItemFactory>(FactoryObject);
+}
+
+void FSurvivalGameEditorModule::ShutdownModule()
+{
+	// TStrongObjectPtr automatically unroots the object if it’s still valid
+	ItemFactory.Reset();
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FSurvivalGameEditorModule, SurvivalGameEditor)

--- a/Source/SurvivalGameEditor/Private/Tools/ItemFactory.cpp
+++ b/Source/SurvivalGameEditor/Private/Tools/ItemFactory.cpp
@@ -1,0 +1,184 @@
+#include "Tools/ItemFactory.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "EditorAssetLibrary.h"
+#include "DataTables/ItemDataTableRow.h"
+#include "PrimaryData/ItemInfo.h"
+#include "Misc/PackageName.h"
+#include "UObject/Package.h"
+#include "HAL/FileManager.h"
+#include "Modules/ModuleManager.h"
+#include "Logging/LogMacros.h"
+#include "Interfaces/IPluginManager.h"
+// For SavePackage + FSavePackageArgs:
+#include "PackageTools.h"  // or "PackageTools.h" in some UE versions
+#include "UObject/UObjectGlobals.h"
+#include "UObject/SavePackage.h"
+
+#if WITH_EDITOR
+
+UItemInfo* UItemFactory::CreateItemDataAsset(FName RowName, const FString& SubPath /*= TEXT("")*/)
+{
+    // 1) Make sure the DataTable is valid
+    if (!ItemDataTable.IsValid())
+    {
+        UE_LOG(LogTemp, Error, TEXT("ItemFactory: No Data Table set!"));
+        return nullptr;
+    }
+
+    UDataTable* Table = ItemDataTable.LoadSynchronous();
+    if (!Table)
+    {
+        UE_LOG(LogTemp, Error, TEXT("ItemFactory: Failed to load Data Table!"));
+        return nullptr;
+    }
+
+    // 2) Find the row in the table
+    FItemDataTableRow* RowData = Table->FindRow<FItemDataTableRow>(RowName, TEXT(""));
+    if (!RowData)
+    {
+        UE_LOG(LogTemp, Error, TEXT("ItemFactory: Row '%s' not found in Data Table!"), *RowName.ToString());
+        return nullptr;
+    }
+
+    // 3) Build a valid package path with NO dot extension
+    //    e.g. "/Game/_MAIN/Data/Items/SubPath/DA_WoodenLog"
+    FString AssetName = FString::Printf(TEXT("DA_%s"), *RowName.ToString());
+    FString PackagePath = GetFullPath(SubPath, AssetName);
+
+    // 4) Create or find the package
+    UPackage* Package = CreatePackage(*PackagePath);
+    if (!Package)
+    {
+        UE_LOG(LogTemp, Error, TEXT("ItemFactory: Failed to create/find package for '%s'"), *PackagePath);
+        return nullptr;
+    }
+
+    // 5) Check if there's already a UItemInfo in that package
+    UItemInfo* NewItem = FindObject<UItemInfo>(Package, *AssetName);
+    if (!NewItem)
+    {
+        // Create a new UItemInfo
+        NewItem = NewObject<UItemInfo>(Package, UItemInfo::StaticClass(), *AssetName, RF_Public | RF_Standalone);
+        if (!NewItem)
+        {
+            UE_LOG(LogTemp, Error, TEXT("ItemFactory: Failed to create '%s'"), *AssetName);
+            return nullptr;
+        }
+        // Inform the asset registry that we've created a new asset
+        FAssetRegistryModule::AssetCreated(NewItem);
+    }
+
+    // 6) Update this item asset with data from the row
+    NewItem->DataTableRowName = RowName;
+    NewItem->LoadFromDataTable(Table);
+
+    // Mark it dirty so the Editor knows it's modified
+    NewItem->MarkPackageDirty();
+
+    // 7) Save the package using FSavePackageArgs
+    FString FilePath = FPackageName::LongPackageNameToFilename(
+        PackagePath,
+        FPackageName::GetAssetPackageExtension()
+    );
+
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    // SaveArgs.Error = GError; // or your own error device
+    // SaveArgs.SaveFlags = SAVE_NoError;
+    // etc.
+
+    const bool bSaved = UPackage::SavePackage(
+        Package,
+        NewItem,
+        *FilePath,
+        SaveArgs
+    );
+
+    if (!bSaved)
+    {
+        UE_LOG(LogTemp, Error, TEXT("ItemFactory: Failed to save package '%s'"), *FilePath);
+        return nullptr;
+    }
+
+    UE_LOG(LogTemp, Log, TEXT("ItemFactory: Successfully created/updated asset '%s'"), *AssetName);
+    return NewItem;
+}
+
+TArray<UItemInfo*> UItemFactory::CreateAllItemAssets()
+{
+    TArray<UItemInfo*> CreatedAssets;
+    if (!ItemDataTable.IsValid())
+    {
+        return CreatedAssets;
+    }
+
+    UDataTable* Table = ItemDataTable.LoadSynchronous();
+    if (!Table)
+    {
+        return CreatedAssets;
+    }
+
+    // Get all row names
+    TArray<FName> RowNames = Table->GetRowNames();
+
+    // Create or update assets for each row
+    for (const FName& RowName : RowNames)
+    {
+        if (UItemInfo* Asset = CreateItemDataAsset(RowName))
+        {
+            CreatedAssets.Add(Asset);
+        }
+    }
+    return CreatedAssets;
+}
+
+void UItemFactory::UpdateAllItems()
+{
+    if (!ItemDataTable.IsValid())
+    {
+        return;
+    }
+
+    UDataTable* Table = ItemDataTable.LoadSynchronous();
+    if (!Table)
+    {
+        return;
+    }
+
+    // Find all existing UItemInfo assets in project
+    TArray<FAssetData> ExistingAssets;
+    FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+
+    FARFilter Filter;
+    Filter.ClassPaths.Add(UItemInfo::StaticClass()->GetClassPathName());
+    AssetRegistryModule.Get().GetAssets(Filter, ExistingAssets);
+
+    // Reload data from the table for each asset
+    for (const FAssetData& AssetData : ExistingAssets)
+    {
+        if (UItemInfo* Item = Cast<UItemInfo>(AssetData.GetAsset()))
+        {
+            if (!Item->DataTableRowName.IsNone())
+            {
+                Item->LoadFromDataTable(Table);
+                Item->MarkPackageDirty();
+            }
+        }
+    }
+}
+
+FString UItemFactory::GetFullPath(const FString& SubPath, const FString& AssetName) const
+{
+    // e.g. BaseContentPath = "/Game/_MAIN/Data/Items"
+    // Combine it with any subfolder, then the final asset name
+    FString FullPath = BaseContentPath;
+
+    if (!SubPath.IsEmpty())
+    {
+        FullPath = FPaths::Combine(FullPath, SubPath);
+    }
+
+    return FPaths::Combine(FullPath, AssetName);
+}
+
+#endif // WITH_EDITOR

--- a/Source/SurvivalGameEditor/Public/SurvivalGameEditor.h
+++ b/Source/SurvivalGameEditor/Public/SurvivalGameEditor.h
@@ -1,0 +1,23 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+#include "UObject/StrongObjectPtr.h"
+#include "Tools/ItemFactory.h"
+
+/**
+ * Editor module for the SurvivalGame. Holds an ItemFactory instance for editor-only usage.
+ */
+class FSurvivalGameEditorModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+
+    /** Returns the ItemFactory instance (if needed elsewhere). */
+    UItemFactory* GetItemFactory() const { return ItemFactory.Get(); }
+
+private:
+    /** Kept alive with a TStrongObjectPtr so it doesn't get GC'ed until we Reset() it. */
+    TStrongObjectPtr<UItemFactory> ItemFactory;
+};

--- a/Source/SurvivalGameEditor/Public/Tools/ItemFactory.h
+++ b/Source/SurvivalGameEditor/Public/Tools/ItemFactory.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "Engine/DataTable.h"
+#include "ItemFactory.generated.h"
+
+class UItemInfo;
+
+/**
+ * UItemFactory
+ * 
+ * Responsible for creating item assets from a given DataTable, 
+ * as well as updating or mass-creating all items in that table.
+ * This should be used only in the editor (WITH_EDITOR).
+ */
+UCLASS()
+class SURVIVALGAMEEDITOR_API UItemFactory : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	// Base path for creating new assets
+	UPROPERTY(EditDefaultsOnly, Category = "Configuration")
+	FString BaseContentPath = TEXT("/Game/_MAIN/Data/Items");
+
+	// The Data Table containing all item definitions
+	UPROPERTY(EditDefaultsOnly, Category = "Configuration")
+	TSoftObjectPtr<UDataTable> ItemDataTable;
+
+#if WITH_EDITOR
+	/**
+	 * Create a single item asset based on the specified row.
+	 * @param RowName Name of the row in the DataTable
+	 * @param SubPath Optional subdirectory path under BaseContentPath for the new asset
+	 * @return The newly created (or updated) UItemInfo asset
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Item Creation")
+	UItemInfo* CreateItemDataAsset(FName RowName, const FString& SubPath = TEXT(""));
+
+	/**
+	 * Create all items from the referenced DataTable.
+	 * @return An array of created/updated UItemInfo assets
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Item Creation")
+	TArray<UItemInfo*> CreateAllItemAssets();
+
+	/**
+	 * Update existing items that match rows in the DataTable.
+	 * (e.g., reloading stats if you changed the DataTable).
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Item Management")
+	void UpdateAllItems();
+
+private:
+	/**
+	 * Helper function to build a valid asset path with no extra dot/extension.
+	 * e.g. /Game/_MAIN/Data/Items/SubPath/AssetName
+	 */
+	FString GetFullPath(const FString& SubPath, const FString& AssetName) const;
+#endif
+};

--- a/Source/SurvivalGameEditor/Public/Tools/ItemFactoryTool.h
+++ b/Source/SurvivalGameEditor/Public/Tools/ItemFactoryTool.h
@@ -1,0 +1,77 @@
+// Add this to your ItemFactoryTool.h
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "EditorUtilityWidget.h"
+#include "Engine/DataTable.h"
+#include "ItemFactory.h"
+#include "Components/ComboBoxString.h" 
+#include "ItemFactoryTool.generated.h"
+
+/**
+ * Editor Utility Widget for creating Item assets from a DataTable
+ */
+UCLASS()
+class SURVIVALGAMEEDITOR_API UItemFactoryTool : public UEditorUtilityWidget
+{
+    GENERATED_BODY()
+
+public:
+    /** The data table containing item definitions we want to create assets for */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Configuration", meta=(DisplayName="Item Data Table"))
+    UDataTable* ItemDataTable;
+    
+    /** Reference to the folder selector combo box */
+    UPROPERTY(BlueprintReadWrite, meta=(BindWidget))
+    UComboBoxString* Combo_FolderSelector;
+    
+    /** Reference to the item selector combo box */
+    UPROPERTY(BlueprintReadWrite, meta=(BindWidget))
+    UComboBoxString* Combo_SelectItem;
+
+    /**
+     * Creates new assets for *all* rows in the data table
+     * and returns an array of the UItemInfo objects that were created.
+     */
+    UFUNCTION(BlueprintCallable, Category = "Item Creation")
+    TArray<UItemInfo*> CreateAllItems()
+    {
+       UItemFactory* Factory = NewObject<UItemFactory>();
+       Factory->ItemDataTable = ItemDataTable;
+       return Factory->CreateAllItemAssets();
+    }
+
+    /**
+     * Creates a single item asset for the specified row name
+     * using the folder path selected in the dropdown.
+     */
+    UFUNCTION(BlueprintCallable, Category = "Item Creation")
+    UItemInfo* CreateSingleItemWithSelectedPath(FName RowName)
+    {
+        if (!Combo_FolderSelector)
+        {
+            return nullptr;
+        }
+    
+        // Get the selected folder path from the combo box
+        FString SelectedFolderPath = Combo_FolderSelector->GetSelectedOption();
+    
+        UItemFactory* Factory = NewObject<UItemFactory>();
+        Factory->ItemDataTable = ItemDataTable;
+    
+        // If it's a full path, override the base path
+        if (SelectedFolderPath.StartsWith(TEXT("/Game/")))
+        {
+            // Extract just the directory part without any filename
+            FString Directory = FPaths::GetPath(SelectedFolderPath);
+            Factory->BaseContentPath = Directory;
+            return Factory->CreateItemDataAsset(RowName);
+        }
+        else
+        {
+            // Use as subpath
+            return Factory->CreateItemDataAsset(RowName, SelectedFolderPath);
+        }
+    }
+};

--- a/Source/SurvivalGameEditor/SurvivalGameEditor.Build.cs
+++ b/Source/SurvivalGameEditor/SurvivalGameEditor.Build.cs
@@ -1,0 +1,36 @@
+﻿using UnrealBuildTool;
+
+public class SurvivalGameEditor : ModuleRules
+{
+	public SurvivalGameEditor(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(new string[] {
+			"Core",
+			"CoreUObject",
+			"Engine",
+			"SurvivalGame",
+			"UMG",            // Add this
+			"Slate",
+			"SlateCore",
+			"Blutility",      // Add this
+			"UMGEditor"       // Add this
+		});
+
+		PrivateDependencyModuleNames.AddRange(new string[] {
+			"UnrealEd",
+			"EditorFramework",
+			"EditorStyle",
+			"EditorSubsystem",
+			"AssetTools",
+			"ContentBrowser",
+			"EditorScriptingUtilities",
+			"DeveloperSettings",
+			"Projects",        // Add this
+			"InputCore",       // Add this
+			"ToolMenus",       // Add this
+			"ApplicationCore"  // Add this
+		});
+	}
+}

--- a/SurvivalGame.uproject
+++ b/SurvivalGame.uproject
@@ -11,6 +11,11 @@
 			"AdditionalDependencies": [
 				"Engine"
 			]
+		},
+		{
+			"Name": "SurvivalGameEditor",
+			"Type": "Editor",
+			"LoadingPhase": "Default"
 		}
 	],
 	"Plugins": [


### PR DESCRIPTION
• Converted the Blueprint-based inventory toggle logic entirely into C++ code.
• In UGameInventoryLayout:
  - Added a cached player controller pointer in NativeConstruct().
  - Implemented NativeOnDeactivated() to call CloseInventory on the cached controller.
  - Restored the inline GetInventoryWidget() function to fix compiler errors in SurvivalPlayerController.
• In SurvivalPlayerController:
  - Set up MasterUILayout creation in CreateMasterLayout() for only local controllers.
  - Implemented InventoryOnClient_Implementation() and CloseInventory_Implementation() purely in C++.
  - Confirmed UI toggling logic works both on listen servers and dedicated servers by checking IsLocalController() before creating UI.
• Ensured the refactored code fully replaces the prior Blueprint approach for inventory toggling and exit button handling.
